### PR TITLE
bumping flask to 2.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-flask~=1.1.2
+flask~=2.1.3
 twilio~=6.38.1
 faker~=4.0.3
 python-dotenv==0.13.0


### PR DESCRIPTION
This repairs https://github.com/TwilioDevEd/voice-javascript-sdk-quickstart-python/issues/11 

Moving to Flask 2 also updates markupsafe which resolves this issue in the codebase https://github.com/pallets/markupsafe/issues/284