### PR TITLE
Correct Werkzeug version 2.* in requirements.txt

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ load_dotenv()
 
 app = Flask(__name__)
 fake = Faker()
-alphanumeric_only = re.compile("[\W_]+")
+alphanumeric_only = re.compile(r"[\W_]+")
 phone_pattern = re.compile(r"^[\d\+\-\(\) ]+$")
 
 twilio_number = os.environ.get("TWILIO_CALLER_ID")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ twilio~=6.38.1
 faker~=4.0.3
 python-dotenv==0.13.0
 pytest==5.4.1
+Werkzeug >= 2, < 3


### PR DESCRIPTION
Since Werkzeug updated to v3, you'll run into:

`ImportError: cannot import name 'url_quote' from 'werkzeug.urls'`

Force Werkzeug >= 2, < 3 in requirements.txt.